### PR TITLE
configure.ac: Only pass a hyphenated suffix to gettext on GTK3 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,8 +64,12 @@ AC_SUBST([LIBEXIF_GTK_EXTENSION])dnl
 # ---------------------------------------------------------------------------
 ALL_LINGUAS="de es fr pl ru"
 AM_PO_SUBDIRS
-GP_GETTEXT_HACK([libexif-${LIBEXIF_GTK_EXTENSION}-${LIBEXIF_GTK_CURRENT}],
-                [Lutz Müller and others])
+if test "$LIBEXIF_GTK_EXTENSION" = "gtk"; then
+    LIBEXIF_GTK_FULLNAME=libexif-$LIBEXIF_GTK_EXTENSION$LIBEXIF_GTK_CURRENT
+else
+    LIBEXIF_GTK_FULLNAME=libexif-$LIBEXIF_GTK_EXTENSION-$LIBEXIF_GTK_CURRENT
+fi
+GP_GETTEXT_HACK([${LIBEXIF_GTK_FULLNAME}], [Lutz Müller and others])
 AM_GNU_GETTEXT_VERSION([0.14.1])
 AM_GNU_GETTEXT([external])
 AM_ICONV


### PR DESCRIPTION
I just realised that my previous change to this area inserted an errant hyphen in libexif-gtk-5. This patch fixes the issue.